### PR TITLE
[protected-scene-loading] Allow overriding ClientChangeScene with sub…

### DIFF
--- a/Runtime/NetworkManager.cs
+++ b/Runtime/NetworkManager.cs
@@ -184,7 +184,7 @@ namespace UnityEngine.Networking
         ///        //Change the Player Spawn Method to be Round Robin (spawn at the spawn points in order)
         ///        playerSpawnMethod = PlayerSpawnMethod.RoundRobin;
         ///    }
-        ///    
+        ///
         ///    void Update()
         ///    {
         ///        //Press the space key to switch the spawn method
@@ -420,7 +420,7 @@ namespace UnityEngine.Networking
         static RemovePlayerMessage s_RemovePlayerMessage = new RemovePlayerMessage();
         static ErrorMessage s_ErrorMessage = new ErrorMessage();
 
-        static AsyncOperation s_LoadingSceneAsync;
+        protected static AsyncOperation s_LoadingSceneAsync;
         static NetworkConnection s_ClientReadyConnection;
 
         // this is used to persist network address between scenes.
@@ -1023,7 +1023,7 @@ namespace UnityEngine.Networking
             }
         }
 
-        internal void ClientChangeScene(string newSceneName, bool forceReload)
+        protected virtual void ClientChangeScene(string newSceneName, bool forceReload)
         {
             if (string.IsNullOrEmpty(newSceneName))
             {
@@ -1421,11 +1421,11 @@ namespace UnityEngine.Networking
         /// //Attach this script to your GameObject.
         /// //Attach a NetworkManagerHUD to your by clicking Add Component in the Inspector window of the GameObject. Then go to Network>NetworkManagerHUD.
         /// //Create a Text GameObject and attach it to the Text field in the Inspector.
-        /// 
+        ///
         /// using UnityEngine;
         /// using UnityEngine.Networking;
         /// using UnityEngine.UI;
-        /// 
+        ///
         /// public class Example : NetworkManager
         /// {
         ///    //Assign a Text component in the GameObject's Inspector
@@ -1437,7 +1437,7 @@ namespace UnityEngine.Networking
         ///        //Change the text to show the connection
         ///        m_Text.text = "Client " + connection.connectionId + " Connected!";
         ///    }
-        /// 
+        ///
         ///    //Detect when a client disconnects from the Server
         ///    public override void OnServerDisconnect(NetworkConnection connection)
         ///    {


### PR DESCRIPTION
…class. Expose s_LoadingSceneAsync, so scene load progress can be displayed.

This was a PR that was made years ago and never merged into the Unity Networking bitbucket repo. I've been using a fork that has this for quite a while. It exposes some of the scene loading functionality to derived classes by making it protected/virtual.

I'm using this to display a loading screen in my game when changing scenes.